### PR TITLE
feat(pomodoro): Update emitted status and enhance DTO with API proper…

### DIFF
--- a/src/pomodoro/dto/create-pomodoro.dto.ts
+++ b/src/pomodoro/dto/create-pomodoro.dto.ts
@@ -1,25 +1,28 @@
 import { IsInt, IsOptional, Min } from "class-validator";
-
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreatePomodoroDto {
+  @ApiProperty({ description: 'Work duration in seconds', required: false, minimum: 1 })
   @IsInt()
   @Min(1)
   @IsOptional()
   workDuration?: number; // seconds
 
+  @ApiProperty({ description: 'Short break duration in seconds', required: false, minimum: 1 })
   @IsInt()
   @Min(1)
   @IsOptional()
   shortBreak?: number; // seconds
 
+  @ApiProperty({ description: 'Long break duration in seconds', required: false, minimum: 1 })
   @IsInt()
   @Min(1)
   @IsOptional()
   longBreak?: number; // seconds
 
+  @ApiProperty({ description: 'Number of work cycles', required: false, minimum: 1 })
   @IsInt()
   @Min(1)
   @IsOptional()
   cycles?: number;
-
 }

--- a/src/pomodoro/pomodoro.gateway.ts
+++ b/src/pomodoro/pomodoro.gateway.ts
@@ -92,7 +92,7 @@ export class PomodoroGateway implements OnGatewayInit, OnGatewayConnection, OnGa
 
   emitStatus(pomodoro: Pomodoro) {
     this.server.to(pomodoro.id.toString()).emit('status', {
-      pomodoroId: pomodoro.id, 
+      _id: pomodoro.id, 
       state: pomodoro.state,
       currentCycle: pomodoro.currentCycle,
       workDuration: pomodoro.workDuration,


### PR DESCRIPTION
…ties

- Changed emitted status property from `pomodoroId` to `_id` for consistency.
- Added Swagger API properties to `CreatePomodoroDto` for better documentation of work duration, short break, long break, and cycles.