### PR TITLE
fix(pomodoro): Populate task in pomodoro retrieval methods

### DIFF
--- a/src/pomodoro/pomodoro.service.ts
+++ b/src/pomodoro/pomodoro.service.ts
@@ -56,7 +56,7 @@ export class PomodoroService {
 
   async findAll(user: mongoose.Types.ObjectId) {
     try{
-      return this.pomodoroModel.find({userId: user, state: PomodoroState.IDLE});
+      return this.pomodoroModel.find({userId: user, state: PomodoroState.IDLE}).populate('task');
     } catch (error) {
       this.logger.error('Error finding pomodoros:', error);
       throw new InternalServerErrorException('Error finding pomodoros');
@@ -65,7 +65,7 @@ export class PomodoroService {
 
   async findAllNotIdle(user: mongoose.Types.ObjectId) {
     try{
-      return await this.pomodoroModel.find({userId: user});
+      return await this.pomodoroModel.find({userId: user}).populate('task');
 
     } catch (error) {
       this.logger.error('Error finding pomodoros:', error);
@@ -85,7 +85,7 @@ export class PomodoroService {
             PomodoroState.IDLE
           ]
         }
-      });
+      }).populate('task');
     } catch (error) {
       this.logger.error('Error finding pomodoros:', error);
       throw new InternalServerErrorException('Error finding pomodoros');


### PR DESCRIPTION
- Updated `findAll`, `findAllNotIdle`, and the retrieval logic to include `task` population for better context in the returned data. This enhances the information available to clients when fetching pomodoros.