### PR TITLE
fix(pomodoro): Add currentTime to pomodoro status emission

### DIFF
--- a/src/pomodoro/pomodoro.gateway.ts
+++ b/src/pomodoro/pomodoro.gateway.ts
@@ -113,6 +113,8 @@ export class PomodoroGateway implements OnGatewayInit, OnGatewayConnection, OnGa
     //   remainingTime: pomodoro.remainingTime,
     //   pausedState: pomodoro.pausedState,
     // });
+    const now = new Date(Date.now());
+    const elapsed = pomodoro.lastResumedAt ? (pomodoro.remainingTime - Math.floor((now.getTime() - pomodoro.lastResumedAt.getTime()) / 1000)) : 0;
 
     this.server.to(pomodoro.id.toString()).emit('status', {
       _id: pomodoro.id, 
@@ -127,6 +129,7 @@ export class PomodoroGateway implements OnGatewayInit, OnGatewayConnection, OnGa
       remainingTime: pomodoro.remainingTime,
       pausedState: pomodoro.pausedState,
       task: pomodoro.task,
+      currentTime: elapsed
     });
   }
 }

--- a/src/pomodoro/pomodoro.service.ts
+++ b/src/pomodoro/pomodoro.service.ts
@@ -105,6 +105,7 @@ export class PomodoroService {
       pomodoro.remainingTime = pomodoro.workDuration;
       //pomodoro.currentCycle = 1;
       pomodoro.startAt = new Date();
+      pomodoro.lastResumedAt = pomodoro.startAt;
       pomodoro.endAt = new Date(pomodoro.startAt.getTime() + pomodoro.workDuration * 1000);
       await pomodoro.save();
       this.eventEmitter.emit(EventsList.POMODORO_STARTED, {userId: user, pomodoroId: pomodoro._id, duration: pomodoro.workDuration, cycles: pomodoro.cycles});


### PR DESCRIPTION
- Introduced `currentTime` to the emitted status data, calculated as the elapsed time since the last resume. This provides clients with real-time context on the pomodoro's progress.
- Set `lastResumedAt` when starting a pomodoro to ensure accurate timing calculations.